### PR TITLE
BaseService 생성자 주입이 아닌 abstract class로 변경

### DIFF
--- a/api/src/test/kotlin/app/foodin/core/service/FoodServiceTest.kt
+++ b/api/src/test/kotlin/app/foodin/core/service/FoodServiceTest.kt
@@ -1,0 +1,36 @@
+package app.foodin.core.service
+
+import app.foodin.domain.user.FoodService
+
+import app.foodin.entity.food.FoodRepository
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+
+@SpringBootTest
+@RunWith(SpringJUnit4ClassRunner::class)
+@ActiveProfiles("test")
+class FoodServiceTest {
+
+    @Autowired
+    private lateinit var foodService: FoodService
+
+    @Autowired
+    private lateinit var foodRepository: FoodRepository
+
+    @Test
+    fun addReviewAndRatingCount() {
+
+        val foodEntity = foodRepository.findAll().first()
+        val old = foodEntity.copy()
+        foodService.addReviewAndRatingCount(foodEntity.id, true)
+        foodRepository.flush()
+
+        assertEquals(old.reviewCount + 1, foodEntity.reviewCount)
+        assertEquals(old.ratingCount + 1, foodEntity.ratingCount)
+    }
+}

--- a/api/src/test/kotlin/app/foodin/core/service/ReviewServiceTest.kt
+++ b/api/src/test/kotlin/app/foodin/core/service/ReviewServiceTest.kt
@@ -1,0 +1,46 @@
+package app.foodin.core.service
+
+import app.foodin.domain.review.ReviewCreateReq
+import app.foodin.domain.user.ReviewService
+import app.foodin.domain.user.User
+import app.foodin.entity.food.FoodEntity
+import app.foodin.entity.food.FoodRepository
+import app.foodin.entity.user.UserEntity
+import app.foodin.entity.user.UserRepository
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner
+
+@SpringBootTest
+@RunWith(SpringJUnit4ClassRunner::class)
+@ActiveProfiles("test")
+class ReviewServiceTest {
+    @Autowired
+    private lateinit var reviewService: ReviewService
+
+    @Autowired
+    private lateinit var foodRepository: FoodRepository
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    private lateinit var user: UserEntity
+    private lateinit var food: FoodEntity
+    @Before
+    fun init() {
+        food = foodRepository.findAll().first()
+        user = userRepository.findAll().first()
+    }
+
+    @Test
+    fun save() {
+        val reviewReq = ReviewCreateReq(
+            foodId = food.id, price = 3000, rating = 3.5f, tagList = mutableListOf("매움"),
+            writeUserId = user.id
+        )
+        reviewService.saveFrom(reviewReq)
+    }
+}

--- a/core/src/main/kotlin/app/foodin/core/service/BaseService.kt
+++ b/core/src/main/kotlin/app/foodin/core/service/BaseService.kt
@@ -6,13 +6,12 @@ import app.foodin.domain.BaseFilter
 import app.foodin.domain.common.BaseDomain
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.transaction.annotation.Transactional
 
-open class BaseService<T : BaseDomain, F : BaseFilter>(
-    private val gateway: BaseGateway<T, F>
-) {
-//    fun findAll(spec: Specification<*>?, pageable: Pageable): Page<T> {
-//        return gateway.findAll(spec, pageable)
-//    }
+abstract class BaseService<T : BaseDomain, F : BaseFilter> {
+    constructor()
+
+    abstract val gateway: BaseGateway<T, F>
 
     fun findAll(filter: F, pageable: Pageable): Page<T> {
         return gateway.findAllByFilter(filter, pageable)

--- a/core/src/main/kotlin/app/foodin/core/service/CodeService.kt
+++ b/core/src/main/kotlin/app/foodin/core/service/CodeService.kt
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Service
 
 @Service
 class CodeService(
-    val codeGateway: CodeGateway
-) : BaseService<Code, CodeFilter>(codeGateway) {
+    override val gateway: CodeGateway
+) : BaseService<Code, CodeFilter>() {
 
     private val logger = LoggerFactory.getLogger(CodeService::class.java)
 }

--- a/core/src/main/kotlin/app/foodin/core/service/FoodCategoryService.kt
+++ b/core/src/main/kotlin/app/foodin/core/service/FoodCategoryService.kt
@@ -9,8 +9,8 @@ import org.springframework.stereotype.Service
 
 @Service
 class FoodCategoryService(
-    private val foodCategoryGateway: FoodCategoryGateway
-) : BaseService<FoodCategory, BaseFilter>(foodCategoryGateway) {
+    override val gateway: FoodCategoryGateway
+) : BaseService<FoodCategory, BaseFilter>() {
 
     private val logger = LoggerFactory.getLogger(FoodCategoryService::class.java)
 }

--- a/core/src/main/kotlin/app/foodin/core/service/ReviewService.kt
+++ b/core/src/main/kotlin/app/foodin/core/service/ReviewService.kt
@@ -8,14 +8,15 @@ import app.foodin.domain.review.ReviewFilter
 import app.foodin.domain.writable.UserWritableInterface
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
-// @Transactional
+@Transactional
 class ReviewService(
-    reviewGateway: ReviewGateway,
+    override val gateway: ReviewGateway,
     private val foodService: FoodService,
     private val userService: UserService
-) : BaseService<Review, ReviewFilter>(reviewGateway), UserWritableInterface {
+) : BaseService<Review, ReviewFilter>(), UserWritableInterface {
 
     private val logger = LoggerFactory.getLogger(ReviewService::class.java)
 


### PR DESCRIPTION
- proxy 객체를 만들면서 super class 의 default 생성자를 만들어서 상속받는 듯
- aop, transactional 등이 class 를 상속받을 때 안될 것 같음
- proxy 객체를 만들 때 어떤 영향이 생기는지 연구해볼 피룡가 있음

또 하나의 회피 방법은 
BaseService에 @Transactional을 붙이면 됨